### PR TITLE
fixed the problem why it can not run under windows 10

### DIFF
--- a/vatsatseg/vatsatseg.py
+++ b/vatsatseg/vatsatseg.py
@@ -307,7 +307,8 @@ def extract_largest_label(mask):
 
     areas = np.array([(r.convex_area, r.label) for r in regions
                       if r.label != 0])
-    areas.view('i8,i8').sort(order=['f0'], axis=0) # sort by area
+    print(areas[0].dtype)
+    areas.view('i4,i4').sort(order=['f0'], axis=0) # sort by area
     ind_largest_label = areas[-1, 1]
 
     return labels == ind_largest_label


### PR DESCRIPTION
If you print the dtype of areas[0], you will find out that it is int32, while the original code wants to divide it into 2 times int32, which is not possible. After this, I have tested it with 1 fat file and 1 water file and it worked.